### PR TITLE
Fix parsing of obfuscated email addresses

### DIFF
--- a/pep_sphinx_extensions/pep_zero_generator/parser.py
+++ b/pep_sphinx_extensions/pep_zero_generator/parser.py
@@ -201,6 +201,6 @@ def _parse_author(data: str) -> list[_Author]:
             raise ValueError("Name is empty!")
 
         author = author.replace(jr_placeholder, ", Jr")
-        email = email.lower()
+        email = email.replace(" at ", "@").lower()
         author_list.append(_Author(author, email))
     return author_list

--- a/pep_sphinx_extensions/tests/pep_zero_generator/test_parser.py
+++ b/pep_sphinx_extensions/tests/pep_zero_generator/test_parser.py
@@ -82,10 +82,9 @@ def test_pep_details(test_input, expected):
             "First Last",
             [_Author(full_name="First Last", email="")],
         ),
-        pytest.param(
+        (
             "First Last <user at example.com>",
             [_Author(full_name="First Last", email="user@example.com")],
-            marks=pytest.mark.xfail,
         ),
         pytest.param(
             " , First Last,",


### PR DESCRIPTION
## Summary
- handle " at " as an email delimiter when parsing authors
- stop expecting failure for that case in tests

## Testing
- `pre-commit run --files pep_sphinx_extensions/pep_zero_generator/parser.py pep_sphinx_extensions/tests/pep_zero_generator/test_parser.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848f3e2e730832da016d7afe7bbd979