### PR TITLE
Normalize obfuscated email addresses in parser

### DIFF
--- a/pep_sphinx_extensions/pep_zero_generator/parser.py
+++ b/pep_sphinx_extensions/pep_zero_generator/parser.py
@@ -201,6 +201,6 @@ def _parse_author(data: str) -> list[_Author]:
             raise ValueError("Name is empty!")
 
         author = author.replace(jr_placeholder, ", Jr")
-        email = email.lower()
+        email = email.replace(" at ", "@").lower()
         author_list.append(_Author(author, email))
     return author_list

--- a/pep_sphinx_extensions/tests/pep_zero_generator/test_parser.py
+++ b/pep_sphinx_extensions/tests/pep_zero_generator/test_parser.py
@@ -82,10 +82,9 @@ def test_pep_details(test_input, expected):
             "First Last",
             [_Author(full_name="First Last", email="")],
         ),
-        pytest.param(
+        (
             "First Last <user at example.com>",
             [_Author(full_name="First Last", email="user@example.com")],
-            marks=pytest.mark.xfail,
         ),
         pytest.param(
             " , First Last,",


### PR DESCRIPTION
## Summary
- convert obfuscated author email addresses using `" at "` to a standard `@` form when parsing PEP metadata
- update the parser tests to cover author strings that use the obfuscated email format

## Testing
- pytest pep_sphinx_extensions/tests/pep_zero_generator/test_parser.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68d46a50b5e0832db60cb37ade96dd92)